### PR TITLE
Add showcase Jenkins pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# jenkins
-# jenkins
+# Jenkins DevOps Showcase
+
+Репозиторий демонстрирует набор продвинутых Jenkins Pipeline сценариев, которые помогают показать компетенции DevOps-инженера. Каждый пайплайн оформлен отдельным Jenkinsfile и фокусируется на своем направлении.
+
+## Список пайплайнов
+
+1. **01_containerized_build.Jenkinsfile** — Maven сборка в Docker с матричными тестами и архивированием артефактов
+2. **02_microservice_matrix.Jenkinsfile** — CI для Node.js микросервиса с матрицей версий и публикацией Docker-образа
+3. **03_infrastructure_delivery.Jenkinsfile** — Работа с Terraform: fmt, plan, ручное подтверждение и apply
+4. **04_kubernetes_canary.Jenkinsfile** — Канареечный релиз в Kubernetes с параллельной проверкой логов, метрик и синтетики
+5. **05_security_compliance.Jenkinsfile** — Комплексная безопасность: SAST, аудит зависимостей, сканирование образа и SonarQube
+6. **06_serverless_ci_cd.Jenkinsfile** — Serverless CI/CD для AWS Lambda с нагрузочным тестированием
+7. **07_mlops_training.Jenkinsfile** — MLOps цикл: контроль качества данных, обучение, валидация и регистрация модели в MLflow
+8. **08_observability_guardrails.Jenkinsfile** — Guardrails для наблюдаемости: promtool, alertmanager, дашборды и синтетика
+9. **09_gitops_sync.Jenkinsfile** — GitOps синхронизация с ArgoCD и проверкой дрейфа инфраструктуры
+10. **10_chatops_release.Jenkinsfile** — ChatOps релиз с подтверждением через Slack и запуском внешнего deploy-job
+
+## Как использовать
+
+Каждый файл можно положить в отдельный Jenkins job или Multibranch Pipeline. Настройте необходимые credentials (см. `credentialsId` внутри файлов) и обновите команды под ваш стек.
+
+## Дополнительно
+
+В корне репозитория оставлен базовый `Jenkinsfile`, который можно использовать как стартовую точку или заменить одним из представленных сценариев.

--- a/pipelines/01_containerized_build.Jenkinsfile
+++ b/pipelines/01_containerized_build.Jenkinsfile
@@ -1,0 +1,65 @@
+// использование docker агента для изоляции build окружения
+pipeline {
+    agent {
+        docker {
+            image 'maven:3.9.6-eclipse-temurin-17'
+            args '-v $HOME/.m2:/root/.m2'
+        }
+    }
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        ansiColor('xterm')
+        buildDiscarder(logRotator(numToKeepStr: '15'))
+    }
+    parameters {
+        choice(name: 'BUILD_PROFILE', choices: ['dev', 'prod'], description: 'Выбор Maven профиля')
+        booleanParam(name: 'RUN_INTEGRATION_TESTS', defaultValue: true, description: 'Запуск интеграционных тестов')
+    }
+    environment {
+        MAVEN_OPTS = '-Dmaven.test.failure.ignore=true'
+        BUILD_NUMBER_DISPLAY = "${env.BUILD_NUMBER}-${params.BUILD_PROFILE}"
+    }
+    stages {
+        stage('Подготовка') {
+            steps {
+                echo "Сборка ${BUILD_NUMBER_DISPLAY}"
+                sh 'java -version'
+                sh 'mvn -version'
+            }
+        }
+        stage('Статический анализ') {
+            steps {
+                sh 'mvn -B verify -P${params.BUILD_PROFILE} -DskipTests'
+            }
+        }
+        stage('Юнит тесты') {
+            steps {
+                sh 'mvn -B test -P${params.BUILD_PROFILE}'
+                junit 'target/surefire-reports/*.xml'
+            }
+        }
+        stage('Интеграция') {
+            when {
+                expression { return params.RUN_INTEGRATION_TESTS }
+            }
+            steps {
+                sh 'mvn -B failsafe:integration-test failsafe:verify -P${params.BUILD_PROFILE}'
+                junit 'target/failsafe-reports/*.xml'
+            }
+        }
+        stage('Артефакты') {
+            steps {
+                sh 'mvn -B package -P${params.BUILD_PROFILE}'
+                archiveArtifacts allowEmptyArchive: false, artifacts: 'target/*.jar'
+            }
+        }
+    }
+    post {
+        success {
+            echo "Сборка ${BUILD_NUMBER_DISPLAY} завершена"
+        }
+        failure {
+            echo "Сборка ${BUILD_NUMBER_DISPLAY} провалилась"
+        }
+    }
+}

--- a/pipelines/02_microservice_matrix.Jenkinsfile
+++ b/pipelines/02_microservice_matrix.Jenkinsfile
@@ -1,0 +1,82 @@
+// матричное тестирование микросервиса с упаковкой в docker
+pipeline {
+    agent any
+    options {
+        timeout(time: 25, unit: 'MINUTES')
+        parallelsAlwaysFailFast()
+        disableConcurrentBuilds()
+    }
+    environment {
+        REGISTRY = 'registry.example.com/company/service'
+    }
+    stages {
+        stage('Получение кода') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Матричные тесты') {
+            matrix {
+                axes {
+                    axis {
+                        name 'NODE_VERSION'
+                        values '18', '20'
+                    }
+                }
+                agent {
+                    docker {
+                        image "node:${NODE_VERSION}-alpine"
+                        args '-u root:root'
+                    }
+                }
+                stages {
+                    stage('Установка зависимостей') {
+                        steps {
+                            sh 'npm ci'
+                        }
+                    }
+                    stage('Запуск тестов') {
+                        steps {
+                            sh 'npm test -- --ci --reporters=jest-junit'
+                            junit 'reports/junit.xml'
+                        }
+                    }
+                }
+                post {
+                    always {
+                        archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/**/*'
+                    }
+                }
+            }
+        }
+        stage('Статический анализ') {
+            steps {
+                sh 'npm run lint'
+            }
+        }
+        stage('Сборка образа') {
+            steps {
+                script {
+                    docker.withRegistry("https://${env.REGISTRY}", 'registry-credentials') {
+                        def app = docker.build("${env.REGISTRY}:${env.BUILD_NUMBER}")
+                        app.push()
+                        app.push('latest')
+                    }
+                }
+            }
+        }
+        stage('Проверка чарта') {
+            steps {
+                sh 'helm lint charts/service'
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Микросервис готов к деплою'
+        }
+        unsuccessful {
+            echo 'Пайплайн остановлен до фикса'
+        }
+    }
+}

--- a/pipelines/03_infrastructure_delivery.Jenkinsfile
+++ b/pipelines/03_infrastructure_delivery.Jenkinsfile
@@ -1,0 +1,62 @@
+// пайплайн для terraform инфраструктуры с ручным подтверждением
+pipeline {
+    agent any
+    options {
+        timeout(time: 40, unit: 'MINUTES')
+        buildDiscarder(logRotator(daysToKeepStr: '10'))
+    }
+    triggers {
+        pollSCM('H/10 * * * *')
+    }
+    environment {
+        TF_IN_AUTOMATION = 'true'
+        BACKEND_BUCKET = 'iac-state-bucket'
+    }
+    stages {
+        stage('Линтинг') {
+            steps {
+                sh 'terraform fmt -check'
+            }
+        }
+        stage('Инициализация') {
+            steps {
+                sh 'terraform init -backend-config="bucket=${BACKEND_BUCKET}"'
+            }
+        }
+        stage('Планирование') {
+            steps {
+                sh 'terraform plan -out=tfplan'
+                stash includes: 'tfplan', name: 'tfplan'
+            }
+        }
+        stage('Одобрение') {
+            steps {
+                script {
+                    timeout(time: 15, unit: 'MINUTES') {
+                        input message: 'Применить изменения инфраструктуры?' , ok: 'Применить'
+                    }
+                }
+            }
+        }
+        stage('Применение') {
+            when {
+                branch 'main'
+            }
+            steps {
+                unstash 'tfplan'
+                sh 'terraform apply -input=false tfplan'
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Инфраструктура обновлена'
+        }
+        failure {
+            sh 'terraform show'
+        }
+        always {
+            cleanWs()
+        }
+    }
+}

--- a/pipelines/04_kubernetes_canary.Jenkinsfile
+++ b/pipelines/04_kubernetes_canary.Jenkinsfile
@@ -1,0 +1,60 @@
+// пайплайн для канареечного релиза в kubernetes с проверкой метрик
+pipeline {
+    agent { label 'k8s-runner' }
+    options {
+        timeout(time: 35, unit: 'MINUTES')
+        timestamps()
+    }
+    parameters {
+        string(name: 'IMAGE_TAG', defaultValue: 'latest', description: 'Тег образа для выката')
+        string(name: 'NAMESPACE', defaultValue: 'production', description: 'Kubernetes пространство')
+    }
+    environment {
+        RELEASE_NAME = 'service-canary'
+        KUBECONFIG = credentials('kubeconfig-prod')
+    }
+    stages {
+        stage('Проверка чарта') {
+            steps {
+                sh 'helm lint charts/service'
+            }
+        }
+        stage('Подготовка релиза') {
+            steps {
+                sh "helm upgrade --install ${RELEASE_NAME} charts/service --namespace ${params.NAMESPACE} --set image.tag=${params.IMAGE_TAG} --set deploymentStrategy=canary --set canary.enabled=true --wait --timeout 5m"
+            }
+        }
+        stage('Наблюдение') {
+            parallel {
+                stage('Проверка логов') {
+                    steps {
+                        sh "kubectl logs deploy/${RELEASE_NAME} -n ${params.NAMESPACE} --tail=200"
+                    }
+                }
+                stage('Метрики') {
+                    steps {
+                        sh 'curl -fsSL http://prometheus/api/v1/query?query=rate(http_requests_total[5m])'
+                    }
+                }
+                stage('Синтетические тесты') {
+                    steps {
+                        sh 'k6 run tests/canary-smoke.js'
+                    }
+                }
+            }
+        }
+        stage('Переключение трафика') {
+            steps {
+                sh "helm upgrade ${RELEASE_NAME} charts/service --namespace ${params.NAMESPACE} --set canary.enabled=false --set replicaCount=6 --wait --timeout 5m"
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Канареечный релиз успешно завершен'
+        }
+        failure {
+            sh "helm rollback ${RELEASE_NAME} 0 --namespace ${params.NAMESPACE}"
+        }
+    }
+}

--- a/pipelines/05_security_compliance.Jenkinsfile
+++ b/pipelines/05_security_compliance.Jenkinsfile
@@ -1,0 +1,64 @@
+// пайплайн безопасной разработки с множеством проверок
+pipeline {
+    agent any
+    options {
+        timeout(time: 45, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+    tools {
+        nodejs 'node20'
+    }
+    environment {
+        SONAR_TOKEN = credentials('sonar-token')
+    }
+    stages {
+        stage('Подготовка зависимостей') {
+            steps {
+                sh 'npm ci'
+            }
+        }
+        stage('Параллельные проверки') {
+            parallel {
+                stage('SAST') {
+                    steps {
+                        sh 'semgrep ci'
+                    }
+                }
+                stage('Dependency Audit') {
+                    steps {
+                        sh 'npm audit --json > audit.json || true'
+                        archiveArtifacts artifacts: 'audit.json', onlyIfSuccessful: false
+                    }
+                }
+                stage('Скан Docker образа') {
+                    steps {
+                        sh 'trivy image --exit-code 0 --format json --output trivy.json company/app:latest'
+                        archiveArtifacts artifacts: 'trivy.json', onlyIfSuccessful: false
+                    }
+                }
+                stage('SonarQube') {
+                    steps {
+                        withSonarQubeEnv('SonarQube') {
+                            sh "sonar-scanner -Dsonar.login=${SONAR_TOKEN}"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Качество политики') {
+            steps {
+                timeout(time: 10, unit: 'MINUTES') {
+                    waitForQualityGate()
+                }
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Продукт прошел комплаенс проверки'
+        }
+        unstable {
+            echo 'Есть замечания безопасности'
+        }
+    }
+}

--- a/pipelines/06_serverless_ci_cd.Jenkinsfile
+++ b/pipelines/06_serverless_ci_cd.Jenkinsfile
@@ -1,0 +1,58 @@
+// пайплайн для serverless приложения с прогоном нагрузочных тестов
+pipeline {
+    agent any
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        durabilityHint('PERFORMANCE_OPTIMIZED')
+    }
+    environment {
+        AWS_DEFAULT_REGION = 'eu-central-1'
+        AWS_ACCESS_KEY_ID = credentials('aws-access')
+        AWS_SECRET_ACCESS_KEY = credentials('aws-secret')
+    }
+    stages {
+        stage('Установка CLI') {
+            steps {
+                sh 'npm install -g serverless artillery'
+            }
+        }
+        stage('Сборка') {
+            steps {
+                sh 'npm ci'
+                sh 'npm run build'
+            }
+        }
+        stage('Тесты') {
+            steps {
+                sh 'npm test'
+            }
+        }
+        stage('Деплой стека') {
+            steps {
+                sh 'serverless deploy --stage prod --conceal'
+            }
+        }
+        stage('Нагрузочное тестирование') {
+            steps {
+                sh 'artillery run tests/load.yml'
+                archiveArtifacts artifacts: 'tests/results/**/*', allowEmptyArchive: true
+            }
+        }
+        stage('Откат') {
+            when {
+                expression { currentBuild.currentResult != 'SUCCESS' }
+            }
+            steps {
+                sh 'serverless rollback'
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Лямбда функции обновлены'
+        }
+        failure {
+            echo 'Деплой прерван'
+        }
+    }
+}

--- a/pipelines/07_mlops_training.Jenkinsfile
+++ b/pipelines/07_mlops_training.Jenkinsfile
@@ -1,0 +1,69 @@
+// пайплайн mlops с версионированием моделей и проверкой данных
+pipeline {
+    agent {
+        docker {
+            image 'python:3.11-slim'
+            args '-u root:root'
+        }
+    }
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+        buildDiscarder(logRotator(numToKeepStr: '8'))
+    }
+    parameters {
+        string(name: 'DATASET_VERSION', defaultValue: '2024-01', description: 'Версия датасета')
+    }
+    environment {
+        MLFLOW_TRACKING_URI = 'http://mlflow:5000'
+    }
+    stages {
+        stage('Установка зависимостей') {
+            steps {
+                sh 'pip install -r requirements.txt'
+            }
+        }
+        stage('Контроль качества данных') {
+            steps {
+                sh "great_expectations checkpoint run training_data --runtime-kwargs '{\"batch_parameters\":{\"version\":\"${params.DATASET_VERSION}\"}}'"
+            }
+        }
+        stage('Подготовка данных') {
+            steps {
+                sh 'python pipelines/preprocess.py --dataset ${params.DATASET_VERSION}'
+                stash includes: 'artifacts/features.parquet', name: 'features'
+            }
+        }
+        stage('Обучение и оценка') {
+            parallel {
+                stage('Обучение') {
+                    steps {
+                        unstash 'features'
+                        sh 'python pipelines/train.py --features artifacts/features.parquet --mlflow ${MLFLOW_TRACKING_URI}'
+                        stash includes: 'artifacts/model.pkl', name: 'model'
+                    }
+                }
+                stage('Валидация') {
+                    steps {
+                        unstash 'features'
+                        sh 'python pipelines/validate.py --features artifacts/features.parquet'
+                        archiveArtifacts allowEmptyArchive: false, artifacts: 'reports/validation/**'
+                    }
+                }
+            }
+        }
+        stage('Регистрация модели') {
+            steps {
+                unstash 'model'
+                sh 'python pipelines/register.py --model artifacts/model.pkl --stage Staging'
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Модель зарегистрирована в MLflow'
+        }
+        failure {
+            echo 'Тренировка требует расследования'
+        }
+    }
+}

--- a/pipelines/08_observability_guardrails.Jenkinsfile
+++ b/pipelines/08_observability_guardrails.Jenkinsfile
@@ -1,0 +1,42 @@
+// пайплайн для контроля наблюдаемости сервисов
+pipeline {
+    agent any
+    options {
+        timeout(time: 20, unit: 'MINUTES')
+        timestamps()
+    }
+    environment {
+        SLACK_CHANNEL = '#observability'
+    }
+    stages {
+        stage('Проверка alertmanager') {
+            steps {
+                sh 'amtool check-config monitoring/alertmanager.yml'
+            }
+        }
+        stage('Проверка правил prometheus') {
+            steps {
+                sh 'promtool check rules monitoring/rules/*.yml'
+                sh 'promtool test rules monitoring/tests/*.test.yml'
+            }
+        }
+        stage('Валидация дашбордов') {
+            steps {
+                sh 'gdevvalidate dashboards/**/*.json'
+            }
+        }
+        stage('Прогон синтетики') {
+            steps {
+                sh 'k6 run tests/observability-smoke.js'
+            }
+        }
+    }
+    post {
+        success {
+            slackSend channel: SLACK_CHANNEL, message: 'Мониторинг в порядке'
+        }
+        failure {
+            slackSend channel: SLACK_CHANNEL, message: 'Нарушены политики наблюдаемости'
+        }
+    }
+}

--- a/pipelines/09_gitops_sync.Jenkinsfile
+++ b/pipelines/09_gitops_sync.Jenkinsfile
@@ -1,0 +1,42 @@
+// пайплайн gitops синхронизации с использованием argocd
+pipeline {
+    agent any
+    options {
+        timeout(time: 25, unit: 'MINUTES')
+    }
+    environment {
+        ARGOCD_AUTH_TOKEN = credentials('argocd-token')
+        ARGOCD_SERVER = 'argocd.example.com'
+    }
+    stages {
+        stage('Генерация манифестов') {
+            steps {
+                sh 'kustomize build environments/prod > dist.yaml'
+                archiveArtifacts artifacts: 'dist.yaml', onlyIfSuccessful: true
+            }
+        }
+        stage('Проверка дрейфа') {
+            steps {
+                sh "argocd app diff platform --server ${ARGOCD_SERVER} --auth-token ${ARGOCD_AUTH_TOKEN} --grpc-web || true"
+            }
+        }
+        stage('Синхронизация') {
+            steps {
+                sh "argocd app sync platform --server ${ARGOCD_SERVER} --auth-token ${ARGOCD_AUTH_TOKEN} --grpc-web --timeout 300"
+            }
+        }
+        stage('Проверка статуса') {
+            steps {
+                sh "argocd app wait platform --server ${ARGOCD_SERVER} --auth-token ${ARGOCD_AUTH_TOKEN} --grpc-web --timeout 300 --health"
+            }
+        }
+    }
+    post {
+        success {
+            echo 'Кластер синхронизирован с git'
+        }
+        failure {
+            echo 'Проверить argocd события'
+        }
+    }
+}

--- a/pipelines/10_chatops_release.Jenkinsfile
+++ b/pipelines/10_chatops_release.Jenkinsfile
@@ -1,0 +1,51 @@
+// пайплайн chatops релиза с подтверждением из slack
+pipeline {
+    agent any
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+    parameters {
+        choice(name: 'TARGET_ENV', choices: ['staging', 'production'], description: 'Среда для релиза')
+    }
+    environment {
+        SLACK_CHANNEL = '#deployments'
+    }
+    stages {
+        stage('Подготовка релиза') {
+            steps {
+                sh 'git fetch --tags'
+                sh 'git describe --tags --abbrev=0 > VERSION'
+                archiveArtifacts artifacts: 'VERSION', onlyIfSuccessful: true
+            }
+        }
+        stage('Согласование') {
+            steps {
+                script {
+                    slackSend channel: SLACK_CHANNEL, message: "Запрошен релиз в ${params.TARGET_ENV}"
+                    timeout(time: 20, unit: 'MINUTES') {
+                        input message: "Одобрить релиз в ${params.TARGET_ENV}?", ok: 'Одобряю'
+                    }
+                }
+            }
+        }
+        stage('Деплой') {
+            steps {
+                build job: 'deploy-service', parameters: [string(name: 'ENV', value: params.TARGET_ENV)]
+            }
+        }
+        stage('Проверка') {
+            steps {
+                sh "./scripts/verify.sh ${params.TARGET_ENV}"
+            }
+        }
+    }
+    post {
+        success {
+            slackSend channel: SLACK_CHANNEL, message: "Релиз ${params.TARGET_ENV} завершен"
+        }
+        failure {
+            slackSend channel: SLACK_CHANNEL, message: "Релиз ${params.TARGET_ENV} упал"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a curated set of 10 Jenkins pipeline examples covering container builds, microservice CI, infrastructure automation, Kubernetes canaries, security checks, serverless deployments, MLOps, observability guardrails, GitOps sync, and ChatOps releases
- document the pipeline catalog and usage guidance in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb00021a748329b1db3a79f54b4790